### PR TITLE
BinaryTree Traits recorridos inorder postorder preorder iterators macro

### DIFF
--- a/array.h
+++ b/array.h
@@ -13,10 +13,7 @@ template <typename Container>
 class array_forward_iterator 
      : public general_iterator<Container,  class array_forward_iterator<Container> > // 
 {public: 
-    // TODO: subir al padre  
-    typedef class general_iterator<Container, array_forward_iterator<Container> > Parent; 
-    typedef typename Container::Node           Node; // 
-    typedef array_forward_iterator<Container>  myself;
+    _ITER_TYPEDEFS(Container, array_forward_iterator)
 
   public:
     array_forward_iterator(Container *pContainer, Node *pNode) 

--- a/binarytree.h
+++ b/binarytree.h
@@ -381,6 +381,38 @@ protected:
             print(pNode->getChild(0), os, level+1);
         }
     }
+
+    void read(istream &is)
+    {
+        using value_type = typename BinaryTree<Traits>::value_type;
+        using LinkedValueType = typename BinaryTree<Traits>::LinkedValueType;
+        value_type key;
+        LinkedValueType value;
+
+        is>>key;
+        is>>value;
+        insert(key, value);
+    }
+
+    template<typename T>
+    friend ostream &operator<<(ostream &os, BinaryTree<T> &obj);
+
+    template<typename T>
+    friend istream &operator>>(istream &is, BinaryTree<T> &obj);
 };
+
+template<typename Traits>
+ostream& operator<<(ostream& os, BinaryTree<Traits>& obj)
+{
+    obj.print(os);
+    return os;
+}
+
+template<typename Traits>
+istream& operator>>(istream& is, BinaryTree<Traits>& obj)
+{
+    obj.read(is);
+    return is;
+}
 
 #endif

--- a/demo.cpp
+++ b/demo.cpp
@@ -186,7 +186,7 @@ void DemoArray(){
     of << v2 << endl; 
     cout << "DemoArray finished !" << endl;
 
-    using TraitStringString = XTrait<string, string  , std::less<KeyNode<string, string> &>>;
+    using TraitStringString = XTrait<string, string, std::less<KeyNode<string, string> &>>;
     CArray< TraitStringString > vx("Ernesto Cuadros");
     vx.insert("Ernesto", "Cuadros");
     vx.insert("Luis"   , "Tejada");
@@ -249,66 +249,41 @@ void DemoHeap()
     cout << "Hello from DemoHeap()" <<endl;
 }
 
-template <typename Node>
-void printAsLine(Node &node, ostream &os){
-    os << " --> " << node.getData()<<"("<<node.getValue()<<")";
-}
-
-template <typename Node>
-void printAsTree(Node &node, ostream &os){
-    os << string(" | ") * node.getLevel() << node.getData()<<"(p:"<<(node.getParent()?to_string(node.getParent()->getData()):"Root")<<",v:"<<node.getValue()<<")"<<endl;
-}
-
-template <typename Container>
-void DemoBinaryTree(Container &container){
-    
-    using value_type = typename Container::value_type;
-    using LinkedValueType = typename Container::LinkedValueType;
-    using Node = typename Container::Node;
-    vector<value_type> keys = {50, 30, 20, 80, 60, 70, 40, 90};
-    vector<LinkedValueType> values = {1, 2, 3, 4, 5, 6, 7, 8};
-    size_t n = keys.size();
-    for(size_t i = 0;i<n;i++){
-        container.insert(keys[i],values[i]);
+template<typename Trait>
+void BinaryTreeHelper()
+{
+    using Container = BinaryTree<Trait>;
+    Container container;
+    using T = typename Container::value_type;
+    vector<T> values = {50, 30, 20, 80, 60, 70, 40, 90};
+    for(auto &v: values)
+    {
+        container.insert(v, v);
     }
-    
-    cout << "\nTREE (p: parent, v: linked value): " << endl;
-    container.print(cout,printAsTree<Node>);
-    cout << endl;
-    cout << "Recorrido inorden: " << endl;
-    container.inorder(cout,printAsLine<Node>);
-    cout << "\nRecorrido postorden: " << endl;
-    container.postorder(cout,printAsLine<Node>);
-    cout << "\nRecorrido preorden: " << endl;
-    container.preorder(cout,printAsLine<Node>);
-    cout << "\n\nVisitando la funcion en forma inorder y sumandole (1) a value: " << endl;
-    LinkedValueType value = 1;
-    container.inorder([](Node& node, LinkedValueType& value){
-        node.getValueRef() = node.getValue() + value;
-    },value);
-    cout << "Recorrido preorden: " << endl;
-    container.preorder(cout,printAsLine<Node>);
 
-    cout<<endl;
+    container.print(cout);
+    cout << "Inorder: ";
+    container.inorder([](T &n){ cout << n << " "; });
+    cout<< endl;
+    cout << "Preorder: ";
+    container.preorder([](T &n){ cout << n << " "; });
+    cout<< endl;
+    cout << "Postorder: ";
+    container.postorder([](T &n){ cout << n << " "; });
+    cout<< endl;
+    cout << "The order printed: ";
+    container.forward([](T &n){ cout << n << " "; });
 
+    cout<< endl;
+    cout<< endl;
 }
 
 void DemoBinaryTree()
-{   
-
-    cout <<endl<< "-----------------------------------DemoBinaryTree------------------------------------" << endl;
-
-    using traitAsc = BinaryTreeTrait< INT,INT, std::less< NodeBinaryTree< INT,INT > > >;
-    using traitDesc = BinaryTreeTrait< INT,INT, std::greater< NodeBinaryTree< INT,INT > > >;
-
-    cout << "---------------------Ascending Binary Tree------------------" << endl;
-    BinaryTree< traitAsc > myAscBinaryTree;
-    DemoBinaryTree(myAscBinaryTree);
-    
-    cout <<endl<< "---------------------Descending Binary Tree------------------" << endl;
-    BinaryTree< traitDesc > myDescBinaryTree;
-    DemoBinaryTree(myDescBinaryTree);
-    cout<<endl;
+{
+    cout << "Ascending BinaryTree..." << endl;
+    BinaryTreeHelper<XTraitIntIntAscCompareVal>();
+    cout << "Descending BinaryTree..." << endl;
+    BinaryTreeHelper<XTraitIntIntDescCompareVal>();
 }
 
 void DemoHash()

--- a/demo.cpp
+++ b/demo.cpp
@@ -261,7 +261,8 @@ void BinaryTreeHelper()
         container.insert(v, v);
     }
 
-    container.print(cout);
+    // container.print(cout);
+    cout << container;
     cout << "Inorder: ";
     container.inorder([](T &n){ cout << n << " "; });
     cout<< endl;
@@ -273,6 +274,11 @@ void BinaryTreeHelper()
     cout<< endl;
     cout << "The order printed: ";
     container.forward([](T &n){ cout << n << " "; });
+
+    cout<<"\nInsert a new element: ";
+    cin>>container;
+    cout<< "Tree with the new element: " << endl;
+    cout<<container;
 
     cout<< endl;
     cout<< endl;

--- a/foreach.h
+++ b/foreach.h
@@ -11,20 +11,11 @@ template <typename T>
 void f1(T &x)
 {  x+= 5; }
 
-// template <typename Iterator, typename F>
-// void foreach(Iterator ItBegin, Iterator ItEnd, F ope){
-//     auto iter = ItBegin;
-//     for(; iter != ItEnd ; ++iter)
-//         ope(*iter);
-//     ope(*iter);
-// }
-
-template <typename Iterator, typename F, typename... Args>
-void foreach(Iterator ItBegin, Iterator ItEnd, F ope, Args&&... args){
-    auto iter = ItBegin;
-    for(; iter != ItEnd ; ++iter)
-        invoke(ope, *iter, forward<Args>(args)...);
-    invoke(ope, *iter, forward<Args>(args)...);
+template <typename Iterator, typename F>
+void foreach(Iterator ItBegin, Iterator ItEnd, F ope)
+{
+  for(auto& iter = ItBegin; iter != ItEnd ; ++iter)
+      ope(*iter);
 }
 
 // template <typename Iterator, typename Callable, typename... Args>

--- a/iterator.h
+++ b/iterator.h
@@ -8,6 +8,7 @@ class general_iterator
 {public:
     typedef typename Container::Node    Node;
     typedef typename Node::Type         Type;
+    typedef typename Node::Type         value_type;
     //typedef class general_iterator<Container> Parent;
     typedef general_iterator<Container, IteratorBase> myself; // 
     
@@ -33,6 +34,12 @@ public:
     bool operator!=(IteratorBase iter)   { return !(*this == iter);        }
     Type &operator*()                    { return m_pNode->getDataRef();   }
 };
+
+#define _ITER_TYPEDEFS(_Container, _iter)  \
+public: \
+    typedef class general_iterator<_Container, _iter<Container> > Parent;     \
+    typedef typename _Container::Node                             Node;       \
+    typedef _iter<_Container>                                     myself;
 
 #endif
  

--- a/main.cpp
+++ b/main.cpp
@@ -16,7 +16,7 @@ int main()
     // DemoReverseIterators();
     // DemoDynamicMatrixes();
 
-    //DemoHeap();
+    // DemoHeap();
     DemoBinaryTree();
     // DemoHash();
 

--- a/matrix.h
+++ b/matrix.h
@@ -8,10 +8,7 @@ template <typename Container>
 class matrix_iterator 
      : public general_iterator<Container,  class matrix_iterator<Container> > // 
 {public: 
-    // TODO: subir al padre  
-    typedef class general_iterator<Container, matrix_iterator<Container> > Parent; 
-    typedef typename Container::Node           Node; // 
-    typedef matrix_iterator<Container>  myself;
+    _ITER_TYPEDEFS(Container, matrix_iterator)
 
     public:
 

--- a/types.h
+++ b/types.h
@@ -2,6 +2,5 @@
 #define __TYPES_H__
 
 using TX = float;
-using INT = int;
 
 #endif

--- a/xtrait.h
+++ b/xtrait.h
@@ -12,4 +12,7 @@ struct XTrait
     using  CompareFn = _CompareFn;
 };
 
+using XTraitIntIntAscCompareVal = XTrait<int, int, std::greater<int>>;
+using XTraitIntIntDescCompareVal = XTrait<int, int, std::less<int>>;
+
 #endif


### PR DESCRIPTION
Estimado dr. Cuadros
Adjunto los cambios realizados a binaryTree, los recorridos con iteradores, el cambio a traits y el uso de una macro
![image](https://github.com/ecuadros/EDA/assets/142927679/7aa2e8b1-5466-43d1-b30b-7217a0c89479)
Ejecucion cambios de generalizar el print (forward iterator) (print ahora solo usa el forward_iterator, es una utilidad y print sigue funcionando pero solo aplicando el general iterator, print es un utility/wrapper alrededor del iterator generalizado)
![image](https://github.com/ecuadros/EDA/assets/142927679/3ab9076e-3a50-4973-a566-f8d8ef0ff87e)
