### PR TITLE
BinaryTree quitar herencia, generalizar print, traits recorridos inorder postorder preorder iterators macro

### DIFF
--- a/array.h
+++ b/array.h
@@ -13,10 +13,7 @@ template <typename Container>
 class array_forward_iterator 
      : public general_iterator<Container,  class array_forward_iterator<Container> > // 
 {public: 
-    // TODO: subir al padre  
-    typedef class general_iterator<Container, array_forward_iterator<Container> > Parent; 
-    typedef typename Container::Node           Node; // 
-    typedef array_forward_iterator<Container>  myself;
+    _ITER_TYPEDEFS(Container, array_forward_iterator)
 
   public:
     array_forward_iterator(Container *pContainer, Node *pNode) 

--- a/binarytree.h
+++ b/binarytree.h
@@ -381,6 +381,38 @@ protected:
             print(pNode->getChild(0), os, level+1);
         }
     }
+
+    void read(istream &is)
+    {
+        using value_type = typename BinaryTree<Traits>::value_type;
+        using LinkedValueType = typename BinaryTree<Traits>::LinkedValueType;
+        value_type key;
+        LinkedValueType value;
+
+        is>>key;
+        is>>value;
+        insert(key, value);
+    }
+
+    template<typename T>
+    friend ostream &operator<<(ostream &os, BinaryTree<T> &obj);
+
+    template<typename T>
+    friend istream &operator>>(istream &is, BinaryTree<T> &obj);
 };
+
+template<typename Traits>
+ostream& operator<<(ostream& os, BinaryTree<Traits>& obj)
+{
+    obj.print(os);
+    return os;
+}
+
+template<typename Traits>
+istream& operator>>(istream& is, BinaryTree<Traits>& obj)
+{
+    obj.read(is);
+    return is;
+}
 
 #endif

--- a/binarytree.h
+++ b/binarytree.h
@@ -1,6 +1,6 @@
 #ifndef __BINARY_TREE_H__  
 #define __BINARY_TREE_H__ 
-//#include <utility>
+#include <utility>
 //#include <algorithm>
 #include <cassert>
 #include <stack>
@@ -50,10 +50,12 @@ private:
 //*****************************************************************************
 //*                               Iterators                                   *
 //*****************************************************************************
+// DONE: Removed Inheritance
 template <typename Container>
-class binary_tree_iterator : public general_iterator<Container, class binary_tree_iterator<Container>> //
+class binary_tree_iterator
 {
     _ITER_TYPEDEFS(Container, binary_tree_iterator); // DONE: llevar esta misma idea a los demas container ya existentes (iterator.h _ITERTYPEDEFS)
+    _ITER_MEMBERS();
 
 public:
     binary_tree_iterator(Container *pContainer, Node *pNode) : Parent(pContainer, pNode) {}
@@ -66,18 +68,31 @@ private:
     }
 };
 
+// DONE: Removed Inheritance
 template <typename Container>
-class binary_tree_iterator_preorder : public general_iterator<Container, class binary_tree_iterator_preorder<Container>> //
+class binary_tree_iterator_preorder
 {
     _ITER_TYPEDEFS(Container, binary_tree_iterator_preorder);
+protected:
+    Container *m_pContainer;
+    Node      *m_pNode;
 public:
-    binary_tree_iterator_preorder(Container *pContainer, Node *pNode) : Parent(pContainer, pNode) {
-        if(!pNode) return;
-        Node* node = pNode;
+    binary_tree_iterator_preorder(Container *pContainer, Node *pNode) : m_pContainer(pContainer), m_pNode(pNode)
+    {
+        if (!pNode)
+            return;
+        Node *node = pNode;
         m_stack.push(node);
     }
-    binary_tree_iterator_preorder(myself &other) : Parent(other) {}
-    binary_tree_iterator_preorder(myself &&other) : Parent(other) {} // Move constructor C++11 en adelante
+    binary_tree_iterator_preorder(myself &other) : m_pContainer(other.m_pContainer), m_pNode(other.m_pNode) {}
+    binary_tree_iterator_preorder(myself &&other)
+    {
+        m_pContainer = move(other.m_pContainer);
+        m_pNode = move(other.m_pNode);
+    }
+
+    Type &operator*()                    { return m_pNode->getDataRef();   }
+
     binary_tree_iterator_preorder operator++()
     { 
         if(m_stack.empty()) return *this;
@@ -109,12 +124,16 @@ private:
     stack<Node *> m_stack;
 };
 
+// DONE: Removed Inheritance
 template <typename Container>
-class binary_tree_iterator_postorder : public general_iterator<Container, class binary_tree_iterator_postorder<Container>> //
+class binary_tree_iterator_postorder
 {
     _ITER_TYPEDEFS(Container, binary_tree_iterator_postorder);
+protected:
+    Container *m_pContainer;
+    Node      *m_pNode;
 public:
-    binary_tree_iterator_postorder(Container *pContainer, Node *pNode) : Parent(pContainer, pNode) {
+    binary_tree_iterator_postorder(Container *pContainer, Node *pNode): m_pContainer(pContainer), m_pNode(pNode) {
         if(!pNode) return;
         stack<Node *> tmpStack;
         Node* curr = pNode;
@@ -143,8 +162,13 @@ public:
             }
         }
     }
-    binary_tree_iterator_postorder(myself &other) : Parent(other) {}
-    binary_tree_iterator_postorder(myself &&other) : Parent(other) {} // Move constructor C++11 en adelante
+    binary_tree_iterator_postorder(myself &other) : m_pContainer(other.m_pContainer), m_pNode(other.m_pNode) {}
+    binary_tree_iterator_postorder(myself &&other)
+    {
+        m_pContainer = move(other.m_pContainer);
+        m_pNode = move(other.m_pNode);
+    }
+
     binary_tree_iterator_postorder operator++()
     { 
         if(m_stack.empty()) return *this;
@@ -161,24 +185,35 @@ public:
     {
         return this->m_stack != other.m_stack;
     }
+
+    Type &operator*()                    { return m_pNode->getDataRef();   }
 private:
     queue<Node *> m_stack;
 };
 
+// DONE: Removed Inheritance
 template<typename Container>
-class binary_tree_iterator_inorder : public general_iterator<Container, class binary_tree_iterator_inorder<Container>> //
+class binary_tree_iterator_inorder
 {
     _ITER_TYPEDEFS(Container, binary_tree_iterator_inorder);
+protected:
+    Container *m_pContainer;
+    Node      *m_pNode;
 public:
-    binary_tree_iterator_inorder(Container *pContainer, Node *pNode) : Parent(pContainer, pNode) {
+    binary_tree_iterator_inorder(Container *pContainer, Node *pNode) : m_pContainer(pContainer), m_pNode(pNode){
         pushStackNodes(pNode);
         if(!this->m_stack.empty()) {
             this->m_pNode = this->m_stack.top();
             m_stack.pop();
         }
     }
-    binary_tree_iterator_inorder(myself &other) : Parent(other) {}
-    binary_tree_iterator_inorder(myself &&other) : Parent(other) {} // Move constructor C++11 en adelante
+    binary_tree_iterator_inorder(myself &other) : m_pContainer(other.m_pContainer), m_pNode(other.m_pNode) {}
+    binary_tree_iterator_inorder(myself &&other)
+    {
+        m_pContainer = move(other.m_pContainer);
+        m_pNode = move(other.m_pNode);
+    }
+
     binary_tree_iterator_inorder operator++() { 
         if(m_stack.empty()) {
             this->m_pNode = nullptr;
@@ -205,42 +240,65 @@ public:
     {
         return this->m_pNode != other.m_pNode;
     }
+    
+    Type &operator*()                    { return m_pNode->getDataRef();   }
 private:
     stack<Node *> m_stack;
 };
 
+template<typename Node>
+struct NodeInfo
+{
+    Node* first;
+    size_t second;
+    NodeInfo(Node* node, size_t level) : first(node), second(level) {}
+};
 
+
+// DONE: Removed Inheritance
 template<typename Container>
-class binary_tree_forward_iterator : public general_iterator<Container, class binary_tree_forward_iterator<Container>> //
+class binary_tree_forward_iterator
 {
     _ITER_TYPEDEFS(Container, binary_tree_forward_iterator);
+protected:
+    Container *m_pContainer;
+    NodeInfo<Node>      *m_pNode;
 public:
-    binary_tree_forward_iterator(Container *pContainer, Node *pNode) : Parent(pContainer, pNode) {
+    binary_tree_forward_iterator(Container *pContainer, NodeInfo<Node> *pNode) : m_pContainer(pContainer), m_pNode(pNode){
+        // cout<<"["<<m_pNode->first->getData()<<"]"<<endl;
+        if(!pNode) return;
         pushStackNodes(pNode);
         if(!m_stack.empty()) {
             this->m_pNode = m_stack.top();
             m_stack.pop();
         }
     }
-    binary_tree_forward_iterator(myself &other) : Parent(other) {}
-    binary_tree_forward_iterator(myself &&other) : Parent(other) {} // Move constructor C++11 en adelante
+    binary_tree_forward_iterator(myself &other) : m_pContainer(other.m_pContainer), m_pNode(other.m_pNode) {}
+    binary_tree_forward_iterator(myself &&other)
+    {
+        m_pContainer = move(other.m_pContainer);
+        m_pNode = move(other.m_pNode);
+    }
     binary_tree_forward_iterator operator++() { 
         if(m_stack.empty()) {
             this->m_pNode = nullptr;
             return *this;
         }
-        Node* node = m_stack.top();
+        NodeInfo<Node>* node = m_stack.top();
         m_stack.pop();
         this->m_pNode = node;
         // cout<<"["<<node->getData()<<"]"<<endl;
-        pushStackNodes(node->getChild(0));
+        pushStackNodes(new NodeInfo<Node>( node->first->getChild(0), node->second + 1 ));
         return *this;
     }
-    void pushStackNodes(Node* node) {
-        Node* tmp = node;
-        while(tmp) {
+    void pushStackNodes(NodeInfo<Node>* node) {
+        NodeInfo<Node>* tmp = node;
+        while(tmp && tmp->first) {
+            // if(node) {
+            //     cout<<tmp->first->getData() << tmp->second <<endl;
+            // }
             m_stack.push(tmp);
-            tmp = tmp->getChild(1);
+            tmp = new NodeInfo<Node>(tmp->first->getChild(1), tmp->second + 1);
         }
     }
     bool operator==(const myself &other) const
@@ -251,8 +309,9 @@ public:
     {
         return this->m_pNode != other.m_pNode;
     }
+    NodeInfo<Node>* &operator*()                    { return m_pNode; }
 private:
-    stack<Node *> m_stack;
+    stack<NodeInfo<Node> *> m_stack;
 };
 
 
@@ -310,7 +369,11 @@ public:
     binary_tree_iterator_preorder <myself> preorderend()   { return binary_tree_iterator_preorder<myself>(this, nullptr); }
     binary_tree_iterator_inorder <myself> inorderbegin() { return binary_tree_iterator_inorder<myself>(this, m_pRoot); }
     binary_tree_iterator_inorder <myself> inorderend()   { return binary_tree_iterator_inorder<myself>(this, nullptr); }
-    binary_tree_forward_iterator <myself> forwardbegin() { return binary_tree_forward_iterator<myself>(this, m_pRoot); }
+    binary_tree_forward_iterator <myself> forwardbegin() { 
+        NodeInfo<Node>* p = new NodeInfo<Node>(m_pRoot, 0);
+        auto it = binary_tree_forward_iterator<myself>(this, p); 
+        return it;
+    }
     binary_tree_forward_iterator <myself> forwardend()   { return binary_tree_forward_iterator<myself>(this, nullptr); }
 protected:
     Node *CreateNode(Node *pParent, value_type &elem, const LinkedValueType &val){ 
@@ -335,8 +398,6 @@ protected:
     // virtual Node* balance(Node* tree);
     virtual Node* balance(Node* tree) { return tree; };
 public:
-    void print    (ostream &os)    {   print    (m_pRoot, os, 0);  }
-
     // DONE: generalize this function by using iterators and apply any function
     template<typename F>
     void postorder(F func) {
@@ -360,27 +421,26 @@ public:
         foreach(forwardbegin(), forwardend(), func);
     }
 
-protected:
-
-    
     // DONE: generalize this function by using iterators and apply any function
-    // Se mantiene esta pero se crea un iterador que recorre el arbol
-    // En el orden en que se imprime. Lo que un iterador conoce es
-    // El inicio, final y el valor. No conoce el nivel. Por lo que esta funcion
-    // Aun es util
-    void print(Node  *pNode, ostream &os, size_t level)
+    // Ahora se tiene el forward iterator, que es la generalizacion de la 
+    // funcion print, es mas, la funcion print solo hace uso del iterator,
+    // pero se puede aplicar el iterator con cualquier funcion
+    void print(ostream &os)
     {
-        // foreach(begin(), end(), print);
-        if( pNode ){
-            Node *pParent = pNode->getParent();
-            print(pNode->getChild(1), os, level+1);
-            //os << string(" | ") * level << pNode->getDataRef() << "(" << (pParent?(pNode->getBranch()?"R-":"L-") + to_string(pParent->getData()):"Root") << ")" <<endl;
-            for(int i = 0; i < level; i++)
-                os << " | ";
-            os << pNode->getDataRef() << "(" << (pParent?to_string(pParent->getData()):"Root") << ")" << "[" << pNode->m_height << "]" <<endl;
-            print(pNode->getChild(0), os, level+1);
-        }
+        // Ahora se hace con un foreach
+        foreach(forwardbegin(), forwardend(), [&os](NodeInfo<Node>* pair) {
+            Node* pNode = pair->first;
+            size_t level = pair->second;
+            if( pNode ){
+                Node *pParent = pNode->getParent();
+                for(size_t i = 0; i < level; i++)
+                    os << " | ";
+                os << pNode->getDataRef() << "(" << (pParent?to_string(pParent->getData()):"Root") << ")" << "[" << pNode->m_height << "]" <<endl;
+            }
+        });
     }
+
+protected:
 
     void read(istream &is)
     {

--- a/demo.cpp
+++ b/demo.cpp
@@ -272,10 +272,17 @@ void BinaryTreeHelper()
     cout << "Postorder: ";
     container.postorder([](T &n){ cout << n << " "; });
     cout<< endl;
-    cout << "The order printed: ";
-    container.forward([](T &n){ cout << n << " "; });
+    cout << "The order printed (with iterator):\n";
+    // Uso del iterator en la funcion print, la funcion print solo es un
+    // utility o wrapper, pero se generalizo con el iterator
+    container.print(cout);
 
-    cout<<"\nInsert a new element: ";
+    cout<< "Showing the use of forward iterator (used in print, now generalized): \n";
+    foreach(container.forwardbegin(), container.forwardend(), [](auto &nodeInfo){ 
+        cout<< "The node " << nodeInfo->first->getData() << " is in the level " << nodeInfo->second << endl;
+    });
+
+    cout<<"\nInsert a new element:\n";
     cin>>container;
     cout<< "Tree with the new element: " << endl;
     cout<<container;

--- a/demo.cpp
+++ b/demo.cpp
@@ -186,7 +186,7 @@ void DemoArray(){
     of << v2 << endl; 
     cout << "DemoArray finished !" << endl;
 
-    using TraitStringString = XTrait<string, string  , std::less<KeyNode<string, string> &>>;
+    using TraitStringString = XTrait<string, string, std::less<KeyNode<string, string> &>>;
     CArray< TraitStringString > vx("Ernesto Cuadros");
     vx.insert("Ernesto", "Cuadros");
     vx.insert("Luis"   , "Tejada");
@@ -249,66 +249,41 @@ void DemoHeap()
     cout << "Hello from DemoHeap()" <<endl;
 }
 
-template <typename Node>
-void printAsLine(Node &node, ostream &os){
-    os << " --> " << node.getData()<<"("<<node.getValue()<<")";
-}
-
-template <typename Node>
-void printAsTree(Node &node, ostream &os){
-    os << string(" | ") * node.getLevel() << node.getData()<<"(p:"<<(node.getParent()?to_string(node.getParent()->getData()):"Root")<<",v:"<<node.getValue()<<")"<<endl;
-}
-
-template <typename Container>
-void DemoBinaryTree(Container &container){
-    
-    using value_type = typename Container::value_type;
-    using LinkedValueType = typename Container::LinkedValueType;
-    using Node = typename Container::Node;
-    vector<value_type> keys = {50, 30, 20, 80, 60, 70, 40, 90};
-    vector<LinkedValueType> values = {1, 2, 3, 4, 5, 6, 7, 8};
-    size_t n = keys.size();
-    for(size_t i = 0;i<n;i++){
-        container.insert(keys[i],values[i]);
+template<typename Trait>
+void BinaryTreeHelper()
+{
+    using Container = BinaryTree<Trait>;
+    Container container;
+    using T = typename Container::value_type;
+    vector<T> values = {50, 30, 20, 80, 60, 70, 40, 90};
+    for(auto &v: values)
+    {
+        container.insert(v, v);
     }
-    
-    cout << "\nTREE (p: parent, v: linked value): " << endl;
-    container.print(cout,printAsTree<Node>);
-    cout << endl;
-    cout << "Recorrido inorden: " << endl;
-    container.inorder(cout,printAsLine<Node>);
-    cout << "\nRecorrido postorden: " << endl;
-    container.postorder(cout,printAsLine<Node>);
-    cout << "\nRecorrido preorden: " << endl;
-    container.preorder(cout,printAsLine<Node>);
-    cout << "\n\nVisitando la funcion en forma inorder y sumandole (1) a value: " << endl;
-    LinkedValueType value = 1;
-    container.inorder([](Node& node, LinkedValueType& value){
-        node.getValueRef() = node.getValue() + value;
-    },value);
-    cout << "Recorrido preorden: " << endl;
-    container.preorder(cout,printAsLine<Node>);
 
-    cout<<endl;
+    container.print(cout);
+    cout << "Inorder: ";
+    container.inorder([](T &n){ cout << n << " "; });
+    cout<< endl;
+    cout << "Preorder: ";
+    container.preorder([](T &n){ cout << n << " "; });
+    cout<< endl;
+    cout << "Postorder: ";
+    container.postorder([](T &n){ cout << n << " "; });
+    cout<< endl;
+    cout << "The order printed: ";
+    container.forward([](T &n){ cout << n << " "; });
 
+    cout<< endl;
+    cout<< endl;
 }
 
 void DemoBinaryTree()
-{   
-
-    cout <<endl<< "-----------------------------------DemoBinaryTree------------------------------------" << endl;
-
-    using traitAsc = BinaryTreeTrait< INT,INT, std::less< NodeBinaryTree< INT,INT > > >;
-    using traitDesc = BinaryTreeTrait< INT,INT, std::greater< NodeBinaryTree< INT,INT > > >;
-
-    cout << "---------------------Ascending Binary Tree------------------" << endl;
-    BinaryTree< traitAsc > myAscBinaryTree;
-    DemoBinaryTree(myAscBinaryTree);
-    
-    cout <<endl<< "---------------------Descending Binary Tree------------------" << endl;
-    BinaryTree< traitDesc > myDescBinaryTree;
-    DemoBinaryTree(myDescBinaryTree);
-    cout<<endl;
+{
+    cout << "Ascending BinaryTree..." << endl;
+    BinaryTreeHelper<XTraitIntIntAscCompareVal>();
+    cout << "Descending BinaryTree..." << endl;
+    BinaryTreeHelper<XTraitIntIntDescCompareVal>();
 }
 
 void DemoHash()

--- a/demo.cpp
+++ b/demo.cpp
@@ -261,7 +261,8 @@ void BinaryTreeHelper()
         container.insert(v, v);
     }
 
-    container.print(cout);
+    // container.print(cout);
+    cout << container;
     cout << "Inorder: ";
     container.inorder([](T &n){ cout << n << " "; });
     cout<< endl;
@@ -273,6 +274,11 @@ void BinaryTreeHelper()
     cout<< endl;
     cout << "The order printed: ";
     container.forward([](T &n){ cout << n << " "; });
+
+    cout<<"\nInsert a new element: ";
+    cin>>container;
+    cout<< "Tree with the new element: " << endl;
+    cout<<container;
 
     cout<< endl;
     cout<< endl;

--- a/foreach.h
+++ b/foreach.h
@@ -11,20 +11,11 @@ template <typename T>
 void f1(T &x)
 {  x+= 5; }
 
-// template <typename Iterator, typename F>
-// void foreach(Iterator ItBegin, Iterator ItEnd, F ope){
-//     auto iter = ItBegin;
-//     for(; iter != ItEnd ; ++iter)
-//         ope(*iter);
-//     ope(*iter);
-// }
-
-template <typename Iterator, typename F, typename... Args>
-void foreach(Iterator ItBegin, Iterator ItEnd, F ope, Args&&... args){
-    auto iter = ItBegin;
-    for(; iter != ItEnd ; ++iter)
-        invoke(ope, *iter, forward<Args>(args)...);
-    invoke(ope, *iter, forward<Args>(args)...);
+template <typename Iterator, typename F>
+void foreach(Iterator ItBegin, Iterator ItEnd, F ope)
+{
+  for(auto& iter = ItBegin; iter != ItEnd ; ++iter)
+      ope(*iter);
 }
 
 // template <typename Iterator, typename Callable, typename... Args>

--- a/iterator.h
+++ b/iterator.h
@@ -8,6 +8,7 @@ class general_iterator
 {public:
     typedef typename Container::Node    Node;
     typedef typename Node::Type         Type;
+    typedef typename Node::Type         value_type;
     //typedef class general_iterator<Container> Parent;
     typedef general_iterator<Container, IteratorBase> myself; // 
     
@@ -33,6 +34,12 @@ public:
     bool operator!=(IteratorBase iter)   { return !(*this == iter);        }
     Type &operator*()                    { return m_pNode->getDataRef();   }
 };
+
+#define _ITER_TYPEDEFS(_Container, _iter)  \
+public: \
+    typedef class general_iterator<_Container, _iter<Container> > Parent;     \
+    typedef typename _Container::Node                             Node;       \
+    typedef _iter<_Container>                                     myself;
 
 #endif
  

--- a/iterator.h
+++ b/iterator.h
@@ -39,7 +39,6 @@ public:
 public: \
     typedef class general_iterator<_Container, _iter<Container> > Parent;     \
     typedef typename _Container::Node                             Node;       \
-    typedef _iter<_Container>                                     myself;
-
+    typedef _iter<_Container>                                     myself;     \
+    typedef typename Node::Type                                   Type; 
 #endif
- 

--- a/main.cpp
+++ b/main.cpp
@@ -16,7 +16,7 @@ int main()
     // DemoReverseIterators();
     // DemoDynamicMatrixes();
 
-    //DemoHeap();
+    // DemoHeap();
     DemoBinaryTree();
     // DemoHash();
 

--- a/matrix.h
+++ b/matrix.h
@@ -8,10 +8,7 @@ template <typename Container>
 class matrix_iterator 
      : public general_iterator<Container,  class matrix_iterator<Container> > // 
 {public: 
-    // TODO: subir al padre  
-    typedef class general_iterator<Container, matrix_iterator<Container> > Parent; 
-    typedef typename Container::Node           Node; // 
-    typedef matrix_iterator<Container>  myself;
+    _ITER_TYPEDEFS(Container, matrix_iterator)
 
     public:
 

--- a/types.h
+++ b/types.h
@@ -2,6 +2,5 @@
 #define __TYPES_H__
 
 using TX = float;
-using INT = int;
 
 #endif

--- a/xtrait.h
+++ b/xtrait.h
@@ -12,4 +12,7 @@ struct XTrait
     using  CompareFn = _CompareFn;
 };
 
+using XTraitIntIntAscCompareVal = XTrait<int, int, std::greater<int>>;
+using XTraitIntIntDescCompareVal = XTrait<int, int, std::less<int>>;
+
 #endif


### PR DESCRIPTION
Estimado dr. Cuadros
Adjunto los cambios realizados a binaryTree, los recorridos con iteradores, el cambio a traits y el uso de una macro

# Quitar herencia y generalizar print
Se hicieron los cambios solicitados en https://github.com/ecuadros/EDA/pull/70#discussion_r1323096929 y https://github.com/ecuadros/EDA/pull/70#discussion_r1323109833
Ejecucion de cambios de generalizar el print (forward iterator) (print ahora solo usa el forward_iterator, es una utilidad y print sigue funcionando pero solo aplicando el general iterator, print es un utility/wrapper alrededor del iterator generalizado)

![image](https://github.com/ecuadros/EDA/assets/142927679/3ab9076e-3a50-4973-a566-f8d8ef0ff87e)

# Cambios anteriores (Print sigue funcionando igual pero ya generalizado)
![image](https://github.com/ecuadros/EDA/assets/142927679/7aa2e8b1-5466-43d1-b30b-7217a0c89479)


