### PR TITLE
B+Tree | Mutex

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -91,6 +91,13 @@
         "memory_resource": "cpp",
         "stop_token": "cpp",
         "thread": "cpp",
-        "cinttypes": "cpp"
+        "cinttypes": "cpp",
+        "xhash": "cpp",
+        "xlocnum": "cpp",
+        "xstring": "cpp",
+        "xtree": "cpp",
+        "xmemory": "cpp",
+        "xtr1common": "cpp",
+        "xutility": "cpp"
     }
 }

--- a/BPlus.cpp
+++ b/BPlus.cpp
@@ -8,6 +8,7 @@
 #include "keynode.h"
 #include "xtrait.h"
 #include "array.h"
+#include <mutex>
 
 using namespace std;
 
@@ -27,6 +28,7 @@ public:
 private:
     
     string    m_name = "Empty";
+    mutex BPlusTree_mutex;
 public:
     CBPlus(string name)  : m_name(name){ destroy();  }
     CBPlus()                           { destroy();  }
@@ -43,7 +45,16 @@ public:
         
     // }
     
-    void insert(const value_type &key, LinkedValueType value){
+    void insert(const value_type &key, LinkedValueType value)
+    {
+        lock_guard<mutex> guard(BPlusTree_mutex);
+
+    }
+
+    void remove(const value_type &key, LinkedValueType value)
+    {
+        lock_guard<mutex> guard(BplusTree_mutex);
+        
     }
 
     void print        (ostream &os){

--- a/demo.cpp
+++ b/demo.cpp
@@ -7,6 +7,7 @@
 #include "array.h"
 #include "matrix.h"
 #include "foreach.h"
+#include <string>
 using namespace std;
 
 template <typename T, int N>


### PR DESCRIPTION
Estimado profesor, 

Se agrega la excepción mutua Mutex, para proteger etapas críticas como son la inserción y la eliminación de elementos.

Un saludo,

Luis Tejada Villagaray